### PR TITLE
Fix invalid symbol mpl.cbook.MatplotlibDepreciationWarning

### DIFF
--- a/src/july/rcmod.py
+++ b/src/july/rcmod.py
@@ -51,5 +51,5 @@ def update_rcparams(
     rcmod["figure.dpi"] = dpi
     rcmod.update(rc_params_dict)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mpl.cbook.MatplotlibDeprecationWarning)
+        warnings.simplefilter("ignore", mpl.MatplotlibDeprecationWarning)
         mpl.rcParams.update(rcmod)


### PR DESCRIPTION
This symbol has moved from mpl.cbook.MatplotlibDepreciationWarning to mpl.MatplotlibDepreciationWarning

Without this fix, jul does not show anything in newer versions of matplotlib.