### PR TITLE
Specify the versions of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     install_requires=[
-        "matplotlib",
-        "numpy",
+        "matplotlib>=3.9.0",
+        "numpy>=1.26.4",
     ],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Since the error come from the change in matplotlib, we need to set the dependency version.